### PR TITLE
Use version range for soda sql spark

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     description="Soda SQL API for PySpark data frame",
     author="Soda",
     install_requires=[
-        "soda-sql-spark==2.1.0b14",  # TODO: Replace version pin with version range
+        "soda-sql-spark>=2.0.0,<3.0.0",
         "pyspark>=3.0.0,<4.0.0",
     ],
     extras_require={


### PR DESCRIPTION
Closes #27. Waiting for a non pre-release version being published for [`soda-spark-sql`](https://pypi.org/project/soda-sql-spark/)