### PR TITLE
Fix data frame with spaces in column name

### DIFF
--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -49,7 +49,7 @@ columns:
     valid_format: uuid
     tests:
     - invalid_percentage == 0
-  feepct:
+  fee pct:
     valid_format: number_percentage
     tests:
     - invalid_percentage == 0
@@ -166,7 +166,7 @@ def df(spark_session: SparkSession) -> DataFrame:
             T.StructField("name", T.StringType(), True),
             T.StructField("size", T.IntegerType(), True),
             T.StructField("date", T.DateType(), True),
-            T.StructField("feepct", T.StringType(), True),
+            T.StructField("fee pct", T.StringType(), True),
             T.StructField("country", T.StringType(), True),
         ]
     )
@@ -283,11 +283,11 @@ def test_scan_execute_with_metric_groups_measurement_as_expected(
         ),
         TestResult(
             test=Test(
-                id='{"column":"feepct","expression":"invalid_percentage == 0"}',
-                title="column(feepct) test(invalid_percentage == 0)",
+                id='{"column":"fee pct","expression":"invalid_percentage == 0"}',
+                title="column(fee pct) test(invalid_percentage == 0)",
                 expression="invalid_percentage == 0",
                 metrics=["invalid_percentage"],
-                column="feepct",
+                column="fee pct",
             ),
             passed=True,
             skipped=False,

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -206,6 +206,16 @@ def test_create_scan_has_spark_dialect(
     assert isinstance(scanner.dialect, SparkDialect)
 
 
+def test_scan_execute_scan_result_does_not_contain_any_errors(
+    scan_definition: str,
+    df: DataFrame,
+) -> None:
+    """The scan results should not contain any erros."""
+
+    scan_result = scan.execute(scan_definition, df)
+    assert not scan_result.has_errors()
+
+
 @pytest.mark.parametrize(
     "measurement",
     [
@@ -324,17 +334,6 @@ def test_scan_execute_contains_expected_test_result(
         test_result == output_test_result
         for output_test_result in scan_result.test_results
     )
-
-
-def test_scan_execute_scan_result_does_not_contain_any_errors(
-    scan_definition: str,
-    df: DataFrame,
-) -> None:
-    """The scan results should not contain any erros."""
-
-    scan_result = scan.execute(scan_definition, df)
-
-    assert not scan_result.has_errors()
 
 
 def test_excluded_columns_date_is_not_present(


### PR DESCRIPTION
Fixes #94 . This is a bug in the Spark dialect. I'll create a PR there to solve it. After that one is released, the tests here should pass.