### PR TITLE
Add scan time support in soda-spark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Add `time` support to `execute`
+
 ## [0.3.1] - 2021-12-27
 
 - Add example to README about returning spark data frames as scan result

--- a/src/sodaspark/scan.py
+++ b/src/sodaspark/scan.py
@@ -265,7 +265,8 @@ def create_scan(
     variables: variables to be substituted in scan yml
     soda_server_client : Optional[SodaServerClient] (default : None)
         A soda server client.
-    time: timestamp date in ISO8601 format (defaul: None)
+    time: Optional[str] (default: None)
+        Timestamp date in ISO8601 format. If None, use datatime.now() in ISO8601 format.
 
     Returns
     -------
@@ -273,10 +274,9 @@ def create_scan(
         The scan.
     """
 
-    if not time:
-        time = dt.datetime.now(tz=dt.timezone.utc).isoformat(
-            timespec="seconds"
-        )
+    time = time or dt.datetime.now(tz=dt.timezone.utc).isoformat(
+        timespec="seconds"
+    )
 
     warehouse = create_warehouse()
     scan = Scan(

--- a/src/sodaspark/scan.py
+++ b/src/sodaspark/scan.py
@@ -253,7 +253,7 @@ def create_scan(
     scan_yml: ScanYml,
     variables: dict | None = None,
     soda_server_client: SodaServerClient | None = None,
-    time: str = dt.datetime.now(tz=dt.timezone.utc).isoformat(timespec="seconds"),
+    time: str | None = None,
 ) -> Scan:
     """
     Create a scan object.
@@ -265,13 +265,19 @@ def create_scan(
     variables: variables to be substituted in scan yml
     soda_server_client : Optional[SodaServerClient] (default : None)
         A soda server client.
-    time: timestamp date in ISO8601 format
+    time: timestamp date in ISO8601 format (defaul: None)
 
     Returns
     -------
     out : Scan
         The scan.
     """
+
+    if not time:
+        time = dt.datetime.now(tz=dt.timezone.utc).isoformat(
+            timespec="seconds"
+        )
+
     warehouse = create_warehouse()
     scan = Scan(
         warehouse=warehouse,
@@ -451,7 +457,10 @@ def execute(
     df.createOrReplaceTempView(scan_yml.table_name)
 
     scan = create_scan(
-        scan_yml, variables=variables, soda_server_client=soda_server_client, time=time
+        scan_yml,
+        variables=variables,
+        soda_server_client=soda_server_client,
+        time=time,
     )
     scan.execute()
 

--- a/src/sodaspark/scan.py
+++ b/src/sodaspark/scan.py
@@ -253,6 +253,7 @@ def create_scan(
     scan_yml: ScanYml,
     variables: dict | None = None,
     soda_server_client: SodaServerClient | None = None,
+    time: str = dt.datetime.now(tz=dt.timezone.utc).isoformat(timespec="seconds"),
 ) -> Scan:
     """
     Create a scan object.
@@ -264,6 +265,7 @@ def create_scan(
     variables: variables to be substituted in scan yml
     soda_server_client : Optional[SodaServerClient] (default : None)
         A soda server client.
+    time: timestamp date in ISO8601 format
 
     Returns
     -------
@@ -276,7 +278,7 @@ def create_scan(
         scan_yml=scan_yml,
         soda_server_client=soda_server_client,
         variables=variables,
-        time=dt.datetime.now(tz=dt.timezone.utc).isoformat(timespec="seconds"),
+        time=time,
     )
     return scan
 
@@ -420,6 +422,7 @@ def execute(
     variables: dict | None = None,
     soda_server_client: SodaServerClient | None = None,
     as_frames: bool | None = False,
+    time: str | None = None,
 ) -> ScanResult:
     """
     Execute a scan on a data frame.
@@ -436,6 +439,8 @@ def execute(
         A soda server client.
     as_frames : bool (default : False)
         Flag to return results in Dataframe
+    time: str (default : None)
+        Timestamp date in ISO8601 format at the start of a scan
 
     Returns
     -------
@@ -446,7 +451,7 @@ def execute(
     df.createOrReplaceTempView(scan_yml.table_name)
 
     scan = create_scan(
-        scan_yml, variables=variables, soda_server_client=soda_server_client
+        scan_yml, variables=variables, soda_server_client=soda_server_client, time=time
     )
     scan.execute()
 


### PR DESCRIPTION
pass scan time with scan configs when create scans